### PR TITLE
Add contribution related documents & update release workflow 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Summary
+_Give a quick summary of the changes this pull request includes._
+
+## Please check if the following applies
+- [ ] The commits in this PR follow the [commit guidelines](https://github.com/realtimeregister/adac-api-client/blob/master/CONTRIBUTING.md)
+- [ ] The pull request was issued to the `master` branch (if not part of a release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: Push release on update master
+name: Push release on update production branch
 
 on:
   push:
     branches:
-      - master
+      - production
 
 permissions:
   contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Commit guidelines
+We follow the conventional commit guidelines as specified by 
+[Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit). With the exception being the scope 
+inside the commit message headers. For `scope` you can use either one of these scopes:
+- `api` - Changes to API logic, e.g. connections and calls;
+- `client` - Changes related to the ADAC client/class;
+- none/empty - changes that don't fall under any of the scopes above, typically seen with type `chore` and `refactor`.
+
+Commits **must** follow these guidelines in order for `semantic-release` to create proper automated releases. 
+Furthermore, this format allows for easier to read commit history. Commits will be evaluated against the 
+[default release rules](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js) 
+of `semantic-release`. This means that:
+- `feat:` would be associated with a `minor` release;
+- `fix:` would be associated with a `patch` release;
+- If `BREAKING CHANGE` is included in the commit message, a `major` release will be triggered;
+- etc.
+
+If your commit closes/fixes any issues, please mention them in the footer of your commit message.
+
+## Publishing a release
+Publishing releases is done automatically by `semantic-release`. This means that the `"version"` inside the 
+`package.json` file should **never** be updated manually as the version management is done by `semantic-release`.
+
+A release publish is triggered by a push to the `production` branch. Merging a PR will immediately trigger this 
+behaviour. This means that changes must be bundled (read 'merged') into the `master` branch first.


### PR DESCRIPTION
This pull requests adds the following documents related to contribution to this repository:
- A pull request template;
- Contribution guidelines.

It also updates the workflow to be inline with the commit guidelines. By creating a different branch for auto-releases we can do releases in desired batches instead of with every change.