### PR TITLE
chore(ci): use trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -28,4 +29,3 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,12 @@
   ],
   "types": "./dist/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/realtimeregister/adac-api-client.git"
   },
   "license": "MIT",
   "main": "./dist/adac-api-client.umd.js",
@@ -39,14 +44,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
-    "@semantic-release/github": "^11.0.0",
-    "@semantic-release/npm": "^12.0.1",
     "@stylistic/eslint-plugin-ts": "^2.8.0",
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^24.2.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "eslint": "^9.11.1",
-    "semantic-release": "^24.1.3",
     "terser": "^5.34.1",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.7.0",


### PR DESCRIPTION
## Summary
Update Github Workflow to use trusted publishing

## Please check if the following applies
- [x] The commits in this PR follow the [commit guidelines](https://github.com/realtimeregister/adac-api-client/blob/master/CONTRIBUTING.md)
- [x] The pull request was issued to the `master` branch (if not part of a release)
